### PR TITLE
Allow re-render of children.

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ export default class PhotoUpload extends React.Component {
 
   renderChildren = props => {
     return React.Children.map(props.children, child => {
-      if (child.type === Image && this.state.avatarSource) {
+      if (child && child.type === Image && this.state.avatarSource) {
         return React.cloneElement(child, {
           source: this.state.avatarSource
         })


### PR DESCRIPTION
My use case was a placeholder svg instead of image. Once onPhotoSelect is triggered I set State of my uri and rerender with an image inside set to the uri. This currently will blow up without the check. This pr fixes that.