### PR TITLE
Add support for custom buttons for onTapCustomButton

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ import RNFS from 'react-native-fs'
 export default class PhotoUpload extends React.Component {
   static propTypes = {
     containerStyle: PropTypes.object,
+    customButtons: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string,
+      title: PropTypes.string,
+    })),
     photoPickerTitle: PropTypes.string,
     height: PropTypes.number,
     width: PropTypes.number,
@@ -42,7 +46,8 @@ export default class PhotoUpload extends React.Component {
     storageOptions: {
       skipBackup: true,
       path: 'images'
-    }
+    },
+    customButtons: this.props.customButtons,
   }
 
   openImagePicker = () => {
@@ -53,9 +58,9 @@ export default class PhotoUpload extends React.Component {
     ImagePicker.showImagePicker(this.options, async response => {
       this.setState({buttonDisabled: false})
       console.log('Response = ', response)
-      let rotation = 0 
+      let rotation = 0
       const {originalRotation} = response
-      
+
 
       if (this.props.onResponse) this.props.onResponse(response)
 
@@ -74,16 +79,16 @@ export default class PhotoUpload extends React.Component {
       }
 
       let { height, width, quality, format } = this.state
-      
+
       //Determining rotation param
-      if ( originalRotation === 90) { 
-        rotation = 90 
-      } else if (originalRotation === 180) { 
-        //For a few images rotation is 180. 
-        rotation = -180 
+      if ( originalRotation === 90) {
+        rotation = 90
+      } else if (originalRotation === 180) {
+        //For a few images rotation is 180.
+        rotation = -180
       } else if ( originalRotation === 270 )  {
         //When taking images with the front camera (selfie), the rotation is 270.
-        rotation = -90 
+        rotation = -90
       }
       // resize image
       const resizedImageUri = await ImageResizer.createResizedImage(


### PR DESCRIPTION
It doesn't make a lot of sense to have an onTapCustomButton prop if you can't pass custom buttons to the image picker. This PR should allow for custom buttons to be passed to display in the image picker.