### PR TITLE
improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,9 +55,9 @@ export default class PhotoUpload extends React.Component {
     ImagePicker.showImagePicker(this.options, async response => {
       this.setState({buttonDisabled: false})
 
-      let rotation = 0 
+      let rotation = 0
       const {originalRotation} = response
-      
+
 
       if (this.props.onResponse) this.props.onResponse(response)
 
@@ -76,42 +76,45 @@ export default class PhotoUpload extends React.Component {
       }
 
       let { maxHeight, maxWidth, quality, format } = this.state
-      
+
       //Determining rotation param
-      if ( originalRotation === 90) { 
-        rotation = 90 
-      } else if (originalRotation === 180) { 
-        //For a few images rotation is 180. 
-        rotation = -180 
+      if ( originalRotation === 90) {
+        rotation = 90
+      } else if (originalRotation === 180) {
+        //For a few images rotation is 180.
+        rotation = -180
       } else if ( originalRotation === 270 )  {
         //When taking images with the front camera (selfie), the rotation is 270.
-        rotation = -90 
+        rotation = -90
       }
-      // resize image
-      const resizedImageUri = await ImageResizer.createResizedImage(
-        `data:image/jpeg;base64,${response.data}`,
-        maxHeight,
-        maxWidth,
-        format,
-        quality,
-        rotation
-      )
+      try { // resize image
+        const resizedImageUri = await ImageResizer.createResizedImage(
+          `data:image/jpeg;base64,${response.data}`,
+          maxHeight,
+          maxWidth,
+          format,
+          quality,
+          rotation
+        )
 
-      if (this.props.onResizedImageUri) this.props.onResizedImageUri(resizedImageUri)
+        if (this.props.onResizedImageUri) this.props.onResizedImageUri(resizedImageUri)
 
-      const filePath = Platform.OS === 'android' && resizedImageUri.uri.replace
-        ? resizedImageUri.uri.replace('file:/data', '/data')
-        : resizedImageUri.uri
+        const filePath = Platform.OS === 'android' && resizedImageUri.uri.replace
+          ? resizedImageUri.uri.replace('file:/data', '/data')
+          : resizedImageUri.uri
 
-      // convert image back to base64 string
-      const photoData = await RNFS.readFile(filePath, 'base64')
-      let source = { uri: resizedImageUri.uri }
-      this.setState({
-        avatarSource: source
-      })
+        // convert image back to base64 string
+        const photoData = await RNFS.readFile(filePath, 'base64')
+        let source = {uri: resizedImageUri.uri}
+        this.setState({
+          avatarSource: source
+        })
 
-      // handle photo in props functions as data string
-      if (this.props.onPhotoSelect) this.props.onPhotoSelect(photoData)
+        // handle photo in props functions as data string
+        if (this.props.onPhotoSelect) this.props.onPhotoSelect(photoData)
+      } catch (e) {
+        if (this.props.onError) this.props.onError(e)
+      }
     })
   }
 


### PR DESCRIPTION
should call `onError` when `ImageResizer.createResizedImage` or `RNFS.readFile` failed