### PR TITLE
Fix width and height prop types and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ check the docs of each library on how to link manually.
  -----|------|------------
  containerStyle | Object | Style object for the image container
  photoPickerTitle | String | Title for the image picker prompt, default is 'Select Photo'
- maxHeight | Number | the resized image max height, maintains aspect ratio, default is 600
- maxWidth | Number | the resized image max width, maintains aspect ratio default is 600
+ height | Number | the resized image max height, maintains aspect ratio, default is 600
+ width | Number | the resized image max width, maintains aspect ratio default is 600
  format | String | The format desired of the resized image, 'JPEG' or 'PNG' default is 'JPEG'
  quality | Number | The quality of the resized image indicated by a number between 1 and 100, default is 100
  onPhotoSelect | Function | function which takes the base64 string of the new image as parameter

--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ export default class PhotoUpload extends React.Component {
   static propTypes = {
     containerStyle: PropTypes.object,
     photoPickerTitle: PropTypes.string,
-    maxHeight: PropTypes.number,
-    maxWidth: PropTypes.number,
+    height: PropTypes.number,
+    width: PropTypes.number,
     format: PropTypes.string,
     quality: PropTypes.number,
     onPhotoSelect: PropTypes.func, // returns the base64 string of uploaded photo


### PR DESCRIPTION
`maxWidth` and `maxHeight` are actually `width` and `height`. PR fixes this in `propTypes` and in README.

Fixes #51, #68. Closes https://github.com/malsapp/react-native-photo-upload/pull/53. 